### PR TITLE
resolve issue #2

### DIFF
--- a/provider/resource_collector.go
+++ b/provider/resource_collector.go
@@ -49,7 +49,7 @@ func resourceCollectorCreate(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("group", id)
 	d.SetId(id)
-	return nil
+	return resourceCollectorRead(d, m)
 }
 
 // resourceCollectorRead checks to see if a specific collector exists
@@ -79,8 +79,7 @@ func resourceCollectorDelete(d *schema.ResourceData, m interface{}) error {
 	if err := bp.DeleteCollector(id); err != nil {
 		return err
 	}
-	d.SetId("")
-	return nil
+	return resourceCollectorRead(d, m)
 }
 
 

--- a/provider/resource_credential.go
+++ b/provider/resource_credential.go
@@ -32,7 +32,7 @@ func resourceCredentialCreate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	d.SetId(x.ID)
-	return nil
+	return resourceCredentialRead(d, m)
 }
 
 func resourceCredentialRead(d *schema.ResourceData, m interface{}) error {
@@ -57,6 +57,5 @@ func resourceCredentialDelete(d *schema.ResourceData, m interface{}) error {
 	if err := bp.DeleteCredential(d.Id()); err != nil {
 		return err
 	}
-	d.SetId("")
-	return nil
+	return resourceCredentialRead(d, m)
 }

--- a/provider/resource_source.go
+++ b/provider/resource_source.go
@@ -133,8 +133,7 @@ func resourceSourceDelete(d *schema.ResourceData, m interface{}) error {
 	if _, err := bp.DeleteSource(d.Id()); err != nil {
 		return err
 	}
-	d.SetId("")
-	return nil
+	return resourceSourceRead(d, m)
 }
 
 func initSource(d *schema.ResourceData) (sdk.SourceConfigCreate, error) {


### PR DESCRIPTION
resolves https://github.com/BlueMedoraPublic/terraform-provider-bindplane/issues/2

tested by deploying and destroying the example/basic deployment. Ran bpcli commands before and after each operation.



<details>
  <summary>Click to expand test output</summary>
NOTE: collector ci-tests is not part of this deployment, it already exists and is used for automated testing from a Jenkins instance.
  
```
➜  basic git:(issue_2) ✗ bpcli collector list && bpcli source list && bpcli credential list && \
    terraform apply -var project=<redacted> -var secret=<redacted> -auto-approve && \
    sleep 30 && \
    bpcli collector list && bpcli source list && bpcli credential list && \
    terraform destroy -var project=<redacted> -var secret=<redacted> -auto-approve && \
    bpcli collector list && bpcli source list && bpcli credential list
    
id: 0a65db1a-7171-4318-8e30-548a9ba6b7af status: Active type: collector version: 3.24.4 name: ci-tests

data.template_file.postgres: Refreshing state...
module.gcp_collector.random_id.suffix: Creating...
module.gcp_collector.random_id.suffix: Creation complete after 0s [id=85wVMVY]
google_compute_instance.postgres: Creating...
module.gcp_collector.data.template_file.user_data: Refreshing state...
module.gcp_collector.google_compute_instance.collector: Creating...
bindplane_credential.postgres: Creating...
bindplane_credential.postgres: Creation complete after 1s [id=b4738280-9a64-4863-b3cd-0d49d762cbb2]
module.gcp_collector.google_compute_instance.collector: Creation complete after 10s [id=gcp-poc-default-f39c153156]
module.gcp_collector.bindplane_collector.collector: Creating...
google_compute_instance.postgres: Still creating... [10s elapsed]
google_compute_instance.postgres: Creation complete after 18s [id=postgres-bp-poc-default]
module.gcp_collector.bindplane_collector.collector: Still creating... [10s elapsed]
module.gcp_collector.bindplane_collector.collector: Still creating... [20s elapsed]
module.gcp_collector.bindplane_collector.collector: Still creating... [30s elapsed]
module.gcp_collector.bindplane_collector.collector: Still creating... [40s elapsed]
module.gcp_collector.bindplane_collector.collector: Still creating... [50s elapsed]
module.gcp_collector.bindplane_collector.collector: Creation complete after 51s [id=515255a5-83f2-491a-b408-27db842c692d]
bindplane_source.postgres_app_db_0: Creating...
bindplane_source.postgres_app_db_0: Still creating... [10s elapsed]
bindplane_source.postgres_app_db_0: Still creating... [20s elapsed]
bindplane_source.postgres_app_db_0: Creation complete after 21s [id=a3010a13-bdfd-4ee1-ac34-dcba4774c845]

Apply complete! Resources: 6 added, 0 changed, 0 destroyed.

id: 0a65db1a-7171-4318-8e30-548a9ba6b7af status: Active type: collector version: 3.24.4 name: ci-tests
id: 515255a5-83f2-491a-b408-27db842c692d status: Active type: collector version: 3.28.1 name: gcp-poc-default-f39c153156
id: a3010a13-bdfd-4ee1-ac34-dcba4774c845 source_type: postgresql status: Active
id: b4738280-9a64-4863-b3cd-0d49d762cbb2 credential_type_id 6c2c63b5-d465-46ef-bfce-b0881066e43b name: postgres

module.gcp_collector.random_id.suffix: Refreshing state... [id=85wVMVY]
data.template_file.postgres: Refreshing state...
bindplane_credential.postgres: Refreshing state... [id=b4738280-9a64-4863-b3cd-0d49d762cbb2]
google_compute_instance.postgres: Refreshing state... [id=postgres-bp-poc-default]
module.gcp_collector.data.template_file.user_data: Refreshing state...
module.gcp_collector.google_compute_instance.collector: Refreshing state... [id=gcp-poc-default-f39c153156]
module.gcp_collector.bindplane_collector.collector: Refreshing state... [id=515255a5-83f2-491a-b408-27db842c692d]
bindplane_source.postgres_app_db_0: Refreshing state... [id=a3010a13-bdfd-4ee1-ac34-dcba4774c845]
bindplane_source.postgres_app_db_0: Destroying... [id=a3010a13-bdfd-4ee1-ac34-dcba4774c845]
bindplane_source.postgres_app_db_0: Destruction complete after 0s
bindplane_credential.postgres: Destroying... [id=b4738280-9a64-4863-b3cd-0d49d762cbb2]
module.gcp_collector.bindplane_collector.collector: Destroying... [id=515255a5-83f2-491a-b408-27db842c692d]
google_compute_instance.postgres: Destroying... [id=postgres-bp-poc-default]
bindplane_credential.postgres: Destruction complete after 0s
module.gcp_collector.bindplane_collector.collector: Destruction complete after 0s
module.gcp_collector.google_compute_instance.collector: Destroying... [id=gcp-poc-default-f39c153156]
google_compute_instance.postgres: Still destroying... [id=postgres-bp-poc-default, 10s elapsed]
module.gcp_collector.google_compute_instance.collector: Still destroying... [id=gcp-poc-default-f39c153156, 10s elapsed]
google_compute_instance.postgres: Still destroying... [id=postgres-bp-poc-default, 20s elapsed]
module.gcp_collector.google_compute_instance.collector: Still destroying... [id=gcp-poc-default-f39c153156, 20s elapsed]
google_compute_instance.postgres: Still destroying... [id=postgres-bp-poc-default, 30s elapsed]
module.gcp_collector.google_compute_instance.collector: Still destroying... [id=gcp-poc-default-f39c153156, 30s elapsed]
google_compute_instance.postgres: Still destroying... [id=postgres-bp-poc-default, 40s elapsed]
module.gcp_collector.google_compute_instance.collector: Still destroying... [id=gcp-poc-default-f39c153156, 40s elapsed]
google_compute_instance.postgres: Still destroying... [id=postgres-bp-poc-default, 50s elapsed]
module.gcp_collector.google_compute_instance.collector: Still destroying... [id=gcp-poc-default-f39c153156, 50s elapsed]
module.gcp_collector.google_compute_instance.collector: Destruction complete after 57s
module.gcp_collector.random_id.suffix: Destroying... [id=85wVMVY]
module.gcp_collector.random_id.suffix: Destruction complete after 0s
google_compute_instance.postgres: Still destroying... [id=postgres-bp-poc-default, 1m0s elapsed]
google_compute_instance.postgres: Still destroying... [id=postgres-bp-poc-default, 1m10s elapsed]
google_compute_instance.postgres: Destruction complete after 1m18s

Destroy complete! Resources: 6 destroyed.

id: 0a65db1a-7171-4318-8e30-548a9ba6b7af status: Active type: collector version: 3.24.4 name: ci-tests

```
</details>
