### PR TITLE
fix source timeoutes

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-const version = "0.2.3"
+const version = "0.2.4"
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{

--- a/provider/bindplane/source/source.go
+++ b/provider/bindplane/source/source.go
@@ -32,73 +32,83 @@ func Create(bp *sdk.BindPlane, source sdk.SourceConfigCreate, timeout int) (Resu
 		return r, errors.Wrap(err, "Not attempting to create source, buildConfig() failed")
 	}
 
-	startTime := time.Now().Unix()
-
-	for {
-		resp, err := bp.CreateSource(config)
-		if err != nil {
-			return r, errors.Wrap(err, string(config))
-		}
-		r.JobID = resp.JobID
-
-		// monitor the job until it finish
-		r.SourceID, err = watchJob(bp, r.JobID)
-
-		// if there is an error, try again until timeout reached
-		if err != nil {
-			timeCurrent := time.Now().Unix()
-			if (timeCurrent - startTime) > int64(timeout) {
-				return r, errors.Wrap(err, "Timeout exceeded for source creation. JobID: "+r.JobID)
-			}
-
-			time.Sleep(5 * time.Second)
-			continue
-
-		}
-
-		return r, nil
+	exists, _, err := sourceExists(bp, source.Name, source.SourceType)
+	if err != nil {
+		return r, errors.Wrap(err, "Failed to check if source already exists")
 	}
+	if exists {
+		return r, errors.New("Cannot create source, already exists")
+	}
+
+	resp, err := bp.CreateSource(config)
+	if err != nil {
+		return r, errors.Wrap(err, string(config))
+	}
+	r.JobID = resp.JobID
+
+	id, err := checkJob(bp, int64(timeout), r.JobID, source)
+	if err != nil {
+		return r, err
+	}
+	r.SourceID = id
+	return r, nil
 }
 
-// returns the sourceID from a completed job
-func watchJob(bp *sdk.BindPlane, jobID string) (string, error) {
+func checkJob(bp *sdk.BindPlane, timeout int64, jobID string, config sdk.SourceConfigCreate) (string, error) {
+	end := time.Now().Unix() + timeout
 	for {
 		job, err := bp.GetJob(jobID)
 		if err != nil {
-			return "", errors.Wrap(err, "Failed to call sdk.GetJob() with job id "+jobID)
+			return "", errors.Wrap(err, "Failed to call sdk.GetJob() with job id: "+jobID)
 		}
 
-		complete, err := parseStatus(job)
+		complete, status, err := parseStatus(job)
 		if err != nil {
 			return "", err
 		}
 
-		if complete == true {
+		if complete {
 			return getSourceID(bp, jobID)
+		} else {
+			// TEMP fallback check if the source exists, even if the job is not in a "complete" state
+			exists, sourceID, err := sourceExists(bp, config.Name, config.SourceType)
+			if err != nil {
+				return "", err
+			}
+			if exists {
+				return sourceID, nil
+			}
 		}
 
-		time.Sleep(5 * time.Second)
-		continue
+		if time.Now().Unix() > end {
+			j, err := json.Marshal(job)
+			if err != nil {
+				return "", errors.New("Timed out waiting for job to complete. Last known status: "+status+". Job id: "+jobID)
+			}
+			return "", errors.New("Timed out waiting for job to complete. Last known status: "+status+". Job: "+string(j))
+		}
+
+		time.Sleep(time.Second * 5)
 	}
 }
 
 // ParseStatus returns true if job complete and an error
 // if job status failed or unexpected
-func parseStatus(job sdk.Job) (bool, error) {
+func parseStatus(job sdk.Job) (bool, string, error) {
 	status := strings.ToLower(job.Status)
 	if status == "complete" {
-		return true, nil
+		return true, status, nil
 	} else if status == "in progress" {
-		return false, nil
+		return false, status, nil
 	} else if status == "testing connection to source" {
-		return false, nil
+		return false, status, nil
 	} else if status == "queued for completion" {
-		return false, nil
+		return false, status, nil
 	} else if status == "failed" {
-		return false, errors.Wrap(jobErr(job), "job: "+job.ID+" failed. "+job.Message)
+		return false, status, errors.Wrap(jobErr(job), "job: "+job.ID+" failed. "+job.Message)
 
 	}
-	return false, errors.Wrap(jobErr(job), "ParseStatus() failed to parse job id "+job.ID)
+	return false, status, errors.Wrap(jobErr(job), "ParseStatus() failed to parse job id "+job.ID)
 }
 
 /*
@@ -139,4 +149,20 @@ func jobErr(job sdk.Job) error {
 		return errors.New("status: " + s + " message: " + m)
 	}
 	return errors.New("status: " + s + " message: " + m + " result: " + r)
+}
+
+func sourceExists(bp *sdk.BindPlane, name, sourceType string) (bool, string, error) {
+	sources, err := bp.GetSources()
+	if err != nil {
+		return false, "", err
+	}
+
+	for _, s := range sources {
+		if sourceType == s.SourceType.ID {
+			if name == s.Name {
+				return true, s.ID, nil
+			}
+		}
+	}
+	return false, "", nil
 }

--- a/provider/bindplane/source/source_test.go
+++ b/provider/bindplane/source/source_test.go
@@ -43,7 +43,7 @@ func TestParseStatus(t *testing.T) {
 	)
 
 	j.Status = "complete"
-	x, err = parseStatus(j)
+	x, _, err = parseStatus(j)
 	if x != true {
 		t.Errorf("Expected parseStatus() to return true when job status is 'complete'")
 	}
@@ -52,7 +52,7 @@ func TestParseStatus(t *testing.T) {
 	}
 
 	j.Status = "in progress"
-	x, err = parseStatus(j)
+	x, _, err = parseStatus(j)
 	if x != false {
 		t.Errorf("Expected parseStatus() to return false when job status is 'in progress'")
 	}
@@ -61,7 +61,7 @@ func TestParseStatus(t *testing.T) {
 	}
 
 	j.Status = "testing connection to source"
-	x, err = parseStatus(j)
+	x, _, err = parseStatus(j)
 	if x != false {
 		t.Errorf("Expected parseStatus() to return false when job status is 'testing connection to source'")
 	}
@@ -70,7 +70,7 @@ func TestParseStatus(t *testing.T) {
 	}
 
 	j.Status = "queued for completion"
-	x, err = parseStatus(j)
+	x, _, err = parseStatus(j)
 	if x != false {
 		t.Errorf("Expected parseStatus() to return false when job status is 'queued for completion'")
 	}
@@ -79,7 +79,7 @@ func TestParseStatus(t *testing.T) {
 	}
 
 	j.Status = "failed"
-	x, err = parseStatus(j)
+	x, _, err = parseStatus(j)
 	if x != false {
 		t.Errorf("Expected parseStatus() to return false when job status is 'failed'")
 	}


### PR DESCRIPTION
- fixed source creation timeout
- add backup method for retrieving source id, if the job api fails.